### PR TITLE
Feature/excution time margins for recorder

### DIFF
--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -7,6 +7,7 @@ namespace AaronFrancis\Pulse\Outdated\Recorders;
 
 use DateInterval;
 use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use Laravel\Pulse\Events\SharedBeat;
 use Laravel\Pulse\Pulse;
@@ -38,6 +39,7 @@ class OutdatedRecorder
     public function record(SharedBeat $event): void
     {
         if ($event->time->diffInSeconds($event->time->copy()->startOfDay()) > 10) {
+            Log::warning('Not Allowed to run now:' .now()->isoFormat('YYYY-MM-DD HH:mm:ss'));
             return;
         }
 
@@ -58,6 +60,9 @@ class OutdatedRecorder
             json_decode($result->output(), flags: JSON_THROW_ON_ERROR);
 
             $this->pulse->set('composer_outdated', 'result', $result->output());
+            Log::warning('Outdatedrecorder has just run: ' . now()->isoFormat('YYYY-MM-DD HH:mm:ss'));
+        } else {
+            Log::warning('Outdated recorder cache hit.');
         }
     }
 }

--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -5,14 +5,18 @@
 
 namespace AaronFrancis\Pulse\Outdated\Recorders;
 
+use DateInterval;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Facades\Process;
 use Laravel\Pulse\Events\SharedBeat;
 use Laravel\Pulse\Pulse;
+use Laravel\Pulse\Recorders\Concerns\Throttling;
 use RuntimeException;
 
 class OutdatedRecorder
 {
+    use Throttling;
+
     /**
      * The events to listen for.
      *
@@ -24,26 +28,36 @@ class OutdatedRecorder
      * Create a new recorder instance.
      */
     public function __construct(
-        protected Pulse $pulse,
+        protected Pulse      $pulse,
         protected Repository $config
-    ) {
+    )
+    {
         //
     }
 
     public function record(SharedBeat $event): void
     {
-        if ($event->time !== $event->time->startOfDay()) {
+        if ($event->time->diffInSeconds($event->time->copy()->startOfDay()) > 10) {
             return;
         }
 
-        $result = Process::run('composer outdated -D -f json');
+        // Throttle key on calendarday
+        $throttleKey = 'shared-beat:composer-outdated:' . $event->time->toDateString();
 
-        if ($result->failed()) {
-            throw new RuntimeException('Composer outdated failed: ' . $result->errorOutput());
+        // Prevent executiion on same day
+        if (!Cache::has($throttleKey)) {
+            // Expire end of the day
+            Cache::put($throttleKey, true, $event->time->copy()->endOfDay());
+
+            $result = Process::run('composer outdated -D -f json');
+
+            if ($result->failed()) {
+                throw new RuntimeException('Composer outdated failed: ' . $result->errorOutput());
+            }
+
+            json_decode($result->output(), flags: JSON_THROW_ON_ERROR);
+
+            $this->pulse->set('composer_outdated', 'result', $result->output());
         }
-
-        json_decode($result->output(), flags: JSON_THROW_ON_ERROR);
-
-        $this->pulse->set('composer_outdated', 'result', $result->output());
     }
 }

--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -5,9 +5,8 @@
 
 namespace AaronFrancis\Pulse\Outdated\Recorders;
 
-use DateInterval;
 use Illuminate\Config\Repository;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Process;
 use Laravel\Pulse\Events\SharedBeat;
 use Laravel\Pulse\Pulse;
@@ -38,8 +37,7 @@ class OutdatedRecorder
 
     public function record(SharedBeat $event): void
     {
-        if ($event->time->diffInSeconds($event->time->copy()->startOfDay()) > 10) {
-            Log::warning('Not Allowed to run now:' .now()->isoFormat('YYYY-MM-DD HH:mm:ss'));
+        if ($event->time->copy()->startOfDay()->diffInSeconds($event->time) > 10) {
             return;
         }
 
@@ -60,9 +58,6 @@ class OutdatedRecorder
             json_decode($result->output(), flags: JSON_THROW_ON_ERROR);
 
             $this->pulse->set('composer_outdated', 'result', $result->output());
-            Log::warning('Outdatedrecorder has just run: ' . now()->isoFormat('YYYY-MM-DD HH:mm:ss'));
-        } else {
-            Log::warning('Outdated recorder cache hit.');
         }
     }
 }

--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -41,10 +41,10 @@ class OutdatedRecorder
             return;
         }
 
-        // Throttle key on calendarday
+        // Throttle key on calendar day
         $throttleKey = 'shared-beat:composer-outdated:' . $event->time->toDateString();
 
-        // Prevent executiion on same day
+        // Prevent execution on same day
         if (!Cache::has($throttleKey)) {
             // Expire end of the day
             Cache::put($throttleKey, true, $event->time->copy()->endOfDay());

--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -37,7 +37,7 @@ class OutdatedRecorder
 
     public function record(SharedBeat $event): void
     {
-        if ($event->time->copy()->startOfDay()->diffInSeconds($event->time) > 10) {
+        if ($event->time->copy()->startOfDay()->diffInSeconds($event->time) > 30) {
             return;
         }
 


### PR DESCRIPTION
To solve the issue that the recorder wont run because of the time restriction i created an update to make it a bit more flexible.

Added caching for the same day to only run it ones within the timeframe it could run (instead of the exact 00:00:00).